### PR TITLE
switched bower install and build post install tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "grunt start",
     "test": "grunt test",
-    "postinstall": "node_modules/grunt-cli/bin/grunt build && bower update"
+    "postinstall": "bower update && node_modules/grunt-cli/bin/grunt build"
   },
   "dependencies": {
     "angular-route": "^1.3.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "grunt start",
     "test": "grunt test",
-    "postinstall": "bower update && node_modules/grunt-cli/bin/grunt build"
+    "postinstall": "node_modules/.bin/bower update && node_modules/grunt-cli/bin/grunt build"
   },
   "dependencies": {
     "angular-route": "^1.3.8",


### PR DESCRIPTION
having a play last night with heroku I noticed that the post install task was the wrong way round. if you install bower after a build it resets all the material design tweaks from build.
